### PR TITLE
feat: improve object generative

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 
 import { streamText } from 'ai';
 import { chromeai } from 'chrome-ai';
-import { z } from 'zod';
 import { PromptCard } from './components/prompt-card';
 import { ChatCard } from './components/chat-card';
 import { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
@@ -13,7 +12,7 @@ import { AlertCircle } from 'lucide-react';
 import { Footer } from './components/footer';
 import { checkEnv } from './utils';
 
-const model = chromeai();
+const model = chromeai('generic');
 
 const HomePage: React.FC<unknown> = () => {
   const [result, setResult] = React.useState<string | undefined>(undefined);
@@ -29,8 +28,8 @@ const HomePage: React.FC<unknown> = () => {
       const startTimestamp = Date.now();
       const { textStream } = await streamText({
         model,
-        prompt,
-        // temperature: 0.8,
+        system: 'You are a helpful assistant.',
+        messages: [{ role: 'user', content: prompt }],
       });
       for await (const textPart of textStream) {
         setResult(textPart);

--- a/src/language-model.test.ts
+++ b/src/language-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { chromeai, ChromeAIChatLanguageModel } from './index';
-import { generateText, streamText, generateObject } from 'ai';
+import { generateText, streamText, generateObject, streamObject } from 'ai';
 import {
   LoadSettingError,
   UnsupportedFunctionalityError,
@@ -66,6 +66,17 @@ describe('chrome-ai', () => {
       finishReason: 'stop',
       text: 'test',
     });
+
+    const resultForMessages = await generateText({
+      model: chromeai(),
+      messages: [
+        { role: 'user', content: 'test' },
+        { role: 'assistant', content: 'assistant' },
+      ],
+    });
+    expect(resultForMessages.text).toBe(
+      'user\ntest\nmodel\nassistant\nmodel\n'
+    );
   });
 
   it('should do stream text', async () => {
@@ -146,6 +157,24 @@ describe('chrome-ai', () => {
         },
       ],
     });
-    expect(result.text).toBe('user:\n\n');
+    expect(result.text).toBe('user\n\nmodel\n');
+
+    await expect(() =>
+      generateObject({
+        model: chromeai(),
+        mode: 'grammar',
+        schema: z.object({}),
+        prompt: 'test',
+      })
+    ).rejects.toThrowError(UnsupportedFunctionalityError);
+
+    await expect(() =>
+      streamObject({
+        model: chromeai(),
+        mode: 'grammar',
+        schema: z.object({}),
+        prompt: 'test',
+      })
+    ).rejects.toThrowError(UnsupportedFunctionalityError);
   });
 });


### PR DESCRIPTION
Make the `generateObject` result more stable through a special prompt:

```
Throughout our conversation, always start your responses with "{" and end with "}", ensuring the output is a concise JSON object and strictly avoid including any comments, notes, explanations, or examples in your output.
For instance, if the JSON schema is {"type":"object","properties":{"someKey":{"type":"string"}},"required":["someKey"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}, your response should immediately begin with "{" and strictly end with "}", following the format: {"someKey": "someValue"}.
Adhere to this format for all queries moving forward.
```