### PR TITLE
fix: remove stream use for smart form

### DIFF
--- a/app/smart-form/page.tsx
+++ b/app/smart-form/page.tsx
@@ -81,7 +81,6 @@ const SmartForm: React.FC<unknown> = () => {
   const { isGenerating } = useAIModel(model, {
     schema,
     messages,
-    stream: true,
     onSuccess: (chunk) => {
       console.log(chunk);
       form.reset(chunk);


### PR DESCRIPTION
I was exploring the demo page for smart form and the paste isn't working, if you run locally and console out the error variable from the hook it will show a `AI_TypeValidationError`, just by removing the stream the paste works fine, let me know if you see a different result.

Opened this other issue in the original lib to investigate: https://github.com/AmAzing129/use-ai-lib/issues/30

