### PR TITLE
feat: update Outputs component to use languageModel capabilities and …

### DIFF
--- a/app/components/outputs.tsx
+++ b/app/components/outputs.tsx
@@ -5,7 +5,7 @@ import { cn } from '../utils';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
 import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
-import { ChromeAICapabilities } from '@/src/enum';
+import { ChromeAIAssistantCapabilities } from '@/src/global';
 
 export interface OutputsProps extends React.HTMLAttributes<HTMLDivElement> { }
 
@@ -27,7 +27,7 @@ export const Outputs = React.forwardRef<
 
     setIsEnabledFlags(!!globalThis.ai?.languageModel);
 
-    globalThis.ai?.languageModel.capabilities().then((cap: ChromeAICapabilities) => {
+    globalThis.ai?.languageModel.capabilities().then((cap: ChromeAIAssistantCapabilities) => {
 
       setIsEnabledFlags(cap.available === 'readily');
     });

--- a/app/components/outputs.tsx
+++ b/app/components/outputs.tsx
@@ -5,8 +5,9 @@ import { cn } from '../utils';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
 import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
+import { ChromeAICapabilities } from '@/src/enum';
 
-export interface OutputsProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface OutputsProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 export const Outputs = React.forwardRef<
   HTMLDivElement,
@@ -24,9 +25,10 @@ export const Outputs = React.forwardRef<
     const version = getChromeVersion();
     // setIsBrowserSupport(version >= 127);
 
-    setIsEnabledFlags(!!globalThis.ai?.assistant);
+    setIsEnabledFlags(!!globalThis.ai?.languageModel);
 
-    globalThis.ai?.assistant.capabilities().then((cap) => {
+    globalThis.ai?.languageModel.capabilities().then((cap: ChromeAICapabilities) => {
+
       setIsEnabledFlags(cap.available === 'readily');
     });
   }, []);

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@vitest/coverage-v8": "^2.0.5",
-    "ai": "^3.3.16",
+    "ai": "^4.0.5",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -13,21 +13,4 @@ export enum ChromeAICapabilityAvailability {
   READILY = 'readily',
 }
 
-export interface ChromeAICapabilities {
-  /**
-   * the availability of the capability
-   */
-  available: ChromeAICapabilityAvailability;
-  /**
-   * the default temperature for the capability
-   */
-  defaultTemperature: number;
-  /**
-   * the default top k for the capability
-   */
-  defaultTopK: number;
-  /**
-   * the maximum top k for the capability
-   */
-  maxTopK: number;
-}
+

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -12,3 +12,22 @@ export enum ChromeAICapabilityAvailability {
    */
   READILY = 'readily',
 }
+
+export interface ChromeAICapabilities {
+  /**
+   * the availability of the capability
+   */
+  available: ChromeAICapabilityAvailability;
+  /**
+   * the default temperature for the capability
+   */
+  defaultTemperature: number;
+  /**
+   * the default top k for the capability
+   */
+  defaultTopK: number;
+  /**
+   * the maximum top k for the capability
+   */
+  maxTopK: number;
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,9 +3,21 @@
 import { ChromeAICapabilityAvailability } from './enum';
 
 export interface ChromeAIAssistantCapabilities {
+  /**
+   * the availability of the capability
+   */
   available: ChromeAICapabilityAvailability;
+  /**
+   * the default temperature for the capability
+   */
   defaultTemperature: number;
+  /**
+   * the default top k for the capability
+   */
   defaultTopK: number;
+  /**
+   * the maximum top k for the capability
+   */
   maxTopK: number;
 }
 


### PR DESCRIPTION
This pull request includes updates to the `Outputs` component, the `package.json` file, and the addition of a new interface in the `src/enum.ts` file. The changes mainly focus on updating the AI capabilities and dependencies.

Updates to the `Outputs` component:

* [`app/components/outputs.tsx`](diffhunk://#diff-c40b3daf22d0ab335c0c38f6a6b11f3d3b680776a396fcc074c2c15c0ec33272R8): Imported `ChromeAICapabilities` from `src/enum`.
* [`app/components/outputs.tsx`](diffhunk://#diff-c40b3daf22d0ab335c0c38f6a6b11f3d3b680776a396fcc074c2c15c0ec33272L27-L29): Modified the logic to use `globalThis.ai?.languageModel` instead of `globalThis.ai?.assistant` and updated the capabilities check to use `ChromeAICapabilities`.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L72-R72): Updated the `ai` package version from `^3.3.16` to `^4.0.5`.

New interface addition:

* [`src/enum.ts`](diffhunk://#diff-2b6db64d876b9624aa31370f0f5b9979cdfb7988662f07de4ed63b7db4feba78R15-R33): Added the `ChromeAICapabilities` interface to define the structure of AI capabilities.…upgrade ai package